### PR TITLE
Implement "cache" of offers grouped by user using LINQ GroupJoin

### DIFF
--- a/src/backend/Controllers/OffersController.cs
+++ b/src/backend/Controllers/OffersController.cs
@@ -39,6 +39,12 @@ namespace backend.Controllers
             _offersService.Save(offer);
         }
 
+        [HttpGet("byUser")]
+        public Dictionary<int, IEnumerable<Offer>> FindGrouped()
+        {
+            return _offersService.GetGrouped();
+        }
+
         public OfferDto ToDto(Offer offer) => new()
         {
             Id = offer.Id,

--- a/src/backend/Repositories/AppDbContext.cs
+++ b/src/backend/Repositories/AppDbContext.cs
@@ -57,13 +57,15 @@ namespace backend.Repositories
             {
                 new Food(1, "Marcipaninis sukutis", "images/sukutis.jpg", "vnt."),
                 new Food(2, "Bananai", "images/bananas.jpg", "kg"),
-                new Food(3, "Cepelinai", "images/cepelinai.jpg", "vnt.")
+                new Food(3, "Cepelinai", "images/cepelinai.jpg", "vnt."),
+                new Food(4, "Pizzas", "", "boxes")
             };
             Offers = new List<Offer>
             {
                 new Offer(1, GetById(Foods, 1), GetById(Users, 2), 3, DateTime.Now, DateTime.Now, "Leftover buns from the last day"),
                 new Offer(2, GetById(Foods, 2), GetById(Users, 1), 1, DateTime.Now, DateTime.Now, "Have nowhere to put these bananas"),
-                new Offer(3, GetById(Foods, 3), GetById(Users, 3), 2, DateTime.Now, DateTime.Now, "Delicious serving made by mistake")
+                new Offer(3, GetById(Foods, 3), GetById(Users, 3), 2, DateTime.Now, DateTime.Now, "Delicious serving made by mistake"),
+                new Offer(2, GetById(Foods, 4), GetById(Users, 1), 4, DateTime.Now, DateTime.Now, "Giving away a few pizzas due to cancelled party")
             };
         }
 

--- a/src/backend/Repositories/OffersRepository.cs
+++ b/src/backend/Repositories/OffersRepository.cs
@@ -1,5 +1,6 @@
 ﻿using backend.Models;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace backend.Repositories
 {
@@ -7,14 +8,32 @@ namespace backend.Repositories
     {
 
         private readonly AppDbContext _appDbContext;
+        public Dictionary<int, IEnumerable<Offer>> OffersByUser { get; private set; }
         public OffersRepository()
         {
             _appDbContext = AppDbContext.GetObject();
+            GroupOffersByUser();
         }
 
-        public void Save(Offer offer)
+        private void GroupOffersByUser()
         {
-            _appDbContext.Offers.Add(offer);
+            var byUser = _appDbContext.Users.GroupJoin(
+                _appDbContext.Offers,
+                user => user,
+                offer => offer.Giver,
+                (user, offerCollection) =>
+                    new
+                    {
+                        UserId = user.Id,
+                        Offers = offerCollection
+                    }).ToDictionary(o => o.UserId, o => o.Offers);
+            OffersByUser = byUser;
+        }
+
+        public void Save(Offer newOffer)
+        {
+            _appDbContext.Offers.Add(newOffer);
+            GroupOffersByUser();
         }
 
         public Offer GetById(int id)

--- a/src/backend/Services/OffersService.cs
+++ b/src/backend/Services/OffersService.cs
@@ -19,6 +19,11 @@ namespace backend.Services
             return _offersRepository.GetById(id);
         }
 
+        public Dictionary<int, IEnumerable<Offer>> GetGrouped()
+        {
+            return _offersRepository.OffersByUser;
+        }
+
         public List<Offer> GetAll()
         {
             return _offersRepository.GetAll();


### PR DESCRIPTION
Here's my attempt at using GroupJoin to group offers into dictionary by user ID. The usefulness is quite questionable and the code is not the cleanest but that's how it is for now. Please review and leave your suggestions if you have any.