### PR TITLE
Replace Find* methods in repositories with queryable Items property

### DIFF
--- a/src/backend/Controllers/SummaryController.cs
+++ b/src/backend/Controllers/SummaryController.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using backend.Data;
+using backend.DTO.Address;
+using backend.DTO.Summary;
+using Microsoft.AspNetCore.Mvc;
+
+namespace backend.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SummaryController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+
+        public SummaryController(AppDbContext db)
+        {
+            _db = db;
+        }
+
+        [HttpGet("cities")]
+        public IEnumerable<CitySummaryDto> Cities()
+        {
+            var offersByCity =
+                _db.Offers
+                    .GroupBy(o => o.Address.City)
+                    .Select(offers => new CitySummaryDto
+                        { City = offers.Key, OffersCount = offers.Count() });
+            
+            return offersByCity;
+        }
+
+        [HttpGet("givers")]
+        public IEnumerable<GiverSummaryDto> Givers()
+        {
+            var giversSummary =
+                _db.Users
+                    .Select(u => new GiverSummaryDto
+                    {
+                        Id = u.Id,
+                        Username = u.Username,
+                        AvatarPath = u.AvatarPath,
+                        Address = new AddressDto
+                        {
+                            Street = u.Address.Street,
+                            City = u.Address.City
+                        },
+                        ActiveOffersCount = u.Offers.Count(o => o.ExpiresAt > DateTime.UtcNow)
+                    })
+                    .Where(a => a.ActiveOffersCount > 0);
+
+            return giversSummary;
+        }
+    }
+}

--- a/src/backend/DTO/Offer/CreateOfferDto.cs
+++ b/src/backend/DTO/Offer/CreateOfferDto.cs
@@ -7,20 +7,42 @@ namespace backend.DTO.Offer
 {
     public class CreateOfferDto : IValidatableObject
     {
+        public string Description { get; set; }
+        public DateTime ExpiresAt { get; set; }
+        public decimal FoodMinQuantity { get; set; }
         public string FoodName { get; set; }
         public IFormFile FoodPhoto { get; set; }
         public string FoodUnit { get; set; }
         public decimal Quantity { get; set; }
-        public DateTime ExpiresAt { get; set; }
-        public string Description { get; set; }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if (ExpiresAt < DateTime.UtcNow)
+            if (ExpiresAt <= DateTime.UtcNow)
             {
                 yield return new ValidationResult(
-                    "Expiration date must be in the future.",
+                    "Expiration date must be in the future",
                     new[] { nameof(ExpiresAt) });
+            }
+
+            if (Quantity <= 0)
+            {
+                yield return new ValidationResult(
+                    "Quantity must be positive",
+                    new[] { nameof(Quantity) });
+            }
+
+            if (FoodMinQuantity is <= 0 or > 1000)
+            {
+                yield return new ValidationResult(
+                    "Minimum Quantity must be positive and not greater than 1000",
+                    new[] { nameof(FoodMinQuantity) });
+            }
+            
+            if (FoodMinQuantity != 0 && Quantity % FoodMinQuantity != 0)
+            {
+                yield return new ValidationResult(
+                    "Quantity must be a factor of Minimum Quantity",
+                    new[] { nameof(Quantity) });
             }
         }
     }

--- a/src/backend/DTO/Offer/FoodDto.cs
+++ b/src/backend/DTO/Offer/FoodDto.cs
@@ -2,6 +2,7 @@ namespace backend.DTO.Offer
 {
     public class FoodDto
     {
+        public decimal MinQuantity { get; set; }
         public string Name { get; set; }
         public string Unit { get; set; }
     }

--- a/src/backend/DTO/Summary/CitySummaryDto.cs
+++ b/src/backend/DTO/Summary/CitySummaryDto.cs
@@ -1,0 +1,8 @@
+namespace backend.DTO.Summary
+{
+    public class CitySummaryDto
+    {
+        public string City { get; set; }
+        public int OffersCount { get; set; }
+    }
+}

--- a/src/backend/DTO/Summary/GiverSummaryDto.cs
+++ b/src/backend/DTO/Summary/GiverSummaryDto.cs
@@ -1,0 +1,9 @@
+using backend.DTO.Offer;
+
+namespace backend.DTO.Summary
+{
+    public class GiverSummaryDto : GiverDto
+    {
+        public int ActiveOffersCount { get; set; }
+    }
+}

--- a/src/backend/Data/DbInitializer.cs
+++ b/src/backend/Data/DbInitializer.cs
@@ -2,8 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 using backend.Models;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace backend.Data
 {
@@ -26,7 +26,7 @@ namespace backend.Data
                 {
                     UserType = UserType.Individual,
                     Email = "edvinas@gmail.com",
-                    Password = "$2a$12$cvSl/uRwdzPSZSHSWCfjleP6r9ShUXKuTy7eJ6IKQxSvKYYNKJsfi",
+                    Password = BCryptNet.HashPassword("pass"),
                     Username = "Edvinas",
                     Address = new Address
                     {
@@ -39,8 +39,8 @@ namespace backend.Data
                     UserType = UserType.Business,
                     Email = "andrius123@lidl.com",
                     AvatarPath = Path.Combine(path, "lidl_logo.jpg"),
-                    Password = "$2a$12$vCAbO6KDewtXbU52lJAm..CoDMoTgS9b85b15Q1lk0MrTEDm3830C",
-                    Username = "Lidl",
+                    Password = BCryptNet.HashPassword("parkside"),
+                    Username = "Lidl Ukmergė",
                     Address = new Address
                     {
                         Street = "Vytauto g. 111A",
@@ -51,8 +51,8 @@ namespace backend.Data
                 {
                     UserType = UserType.Business,
                     Email = "inga@etnodvaras.lt",
-                    Password = "$2a$12$HQ2IgAaIaqvIXLX7hqP4uuzESajwdsojqiVVsRz2FSh.C22qiyQ0i",
-                    Username = "Etno dvaras",
+                    Password = BCryptNet.HashPassword("manozepelinas"),
+                    Username = "Etno dvaras BIG",
                     AvatarPath = Path.Combine(path, "etno_dvaras_logo.png"),
                     Address = new Address
                     {
@@ -70,45 +70,51 @@ namespace backend.Data
                 new()
                 {
                     Quantity = 5.0m,
+                    AvailableQuantity = 5.0m,
                     Description = "Have nowhere to put these bananas",
                     CreatedAt = DateTime.UtcNow.Subtract(TimeSpan.FromHours(random.Next(1, 8))),
                     ExpiresAt = DateTime.UtcNow.AddDays(5),
-                    Giver = db.Users.Find(1),
-                    Address = db.Users.Include(u => u.Address).First(u => u.Id == 1).Address,
+                    Giver = users[0],
+                    Address = users[0].Address,
                     Food = new Food
                     {
-                        Name = "Bananai",
+                        Name = "Bananas",
                         Unit = "kg",
+                        MinQuantity = 0.5m,
                         ImagePath = Path.Combine(path, "bananas.jpg")
                     }
                 },
                 new()
                 {
                     Quantity = 8.0m,
+                    AvailableQuantity = 8.0m,
                     Description = "Leftover buns from the last day",
                     CreatedAt = DateTime.UtcNow.Subtract(TimeSpan.FromHours(random.Next(1, 8))),
                     ExpiresAt = DateTime.UtcNow.AddDays(2),
-                    Giver = db.Users.Find(2),
-                    Address = db.Users.Include(u => u.Address).First(u => u.Id == 2).Address,
+                    Giver = users[1],
+                    Address = users[1].Address,
                     Food = new Food
                     {
                         Name = "Marcipaninis sukutis",
                         Unit = "pcs",
+                        MinQuantity = 1,
                         ImagePath = Path.Combine(path, "sukutis.jpg")
                     }
                 },
                 new()
                 {
                     Quantity = 2.0m,
+                    AvailableQuantity = 2.0m,
                     Description = "Delicious serving made by mistake",
                     CreatedAt = DateTime.UtcNow.Subtract(TimeSpan.FromHours(random.Next(1, 8))),
                     ExpiresAt = DateTime.UtcNow.AddHours(12),
-                    Giver = db.Users.Find(3),
-                    Address = db.Users.Include(u => u.Address).First(u => u.Id == 3).Address,
+                    Giver = users[2],
+                    Address = users[2].Address,
                     Food = new Food
                     {
-                        Name = "Cepelinai",
+                        Name = "Zeppelins",
                         Unit = "pcs",
+                        MinQuantity = 1,
                         ImagePath = Path.Combine(path, "cepelinai.jpg")
                     }
                 }

--- a/src/backend/Models/Food.cs
+++ b/src/backend/Models/Food.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace backend.Models
@@ -13,5 +14,7 @@ namespace backend.Models
         public string ImagePath { get; set; }
         [Required]
         public string Unit { get; set; }
+        [DefaultValue(1)]
+        public decimal MinQuantity { get; set; }
     }
 }

--- a/src/backend/Program.cs
+++ b/src/backend/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Globalization;
+using System.Threading;
 using backend.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +14,14 @@ namespace backend
     {
         public static void Main(string[] args)
         {
+            var culture = CultureInfo.CreateSpecificCulture("en-US");
+
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+            
             var host = CreateHostBuilder(args).Build();
             
             using (var scope = host.Services.CreateScope())

--- a/src/backend/Repositories/IRepositoryBase.cs
+++ b/src/backend/Repositories/IRepositoryBase.cs
@@ -1,13 +1,10 @@
-using System;
 using System.Linq;
-using System.Linq.Expressions;
 
 namespace backend.Repositories
 {
     public interface IRepositoryBase<T>
     {
-        IQueryable<T> FindAll();
-        IQueryable<T> FindByCondition(Expression<Func<T, bool>> expression);
+        IQueryable<T> Items { get; }
         void Create(T entity);
     }
 }

--- a/src/backend/Repositories/OffersRepository.cs
+++ b/src/backend/Repositories/OffersRepository.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Linq;
-using System.Linq.Expressions;
 using backend.Data;
 using backend.DTO.Offer;
 using backend.Models;
@@ -12,6 +10,18 @@ namespace backend.Repositories
     {
         private readonly AppDbContext _db;
 
+        public IQueryable<Offer> Items
+        {
+            get
+            {
+                return _db.Offers
+                    .Include(o => o.Address)
+                    .Include(o => o.Food)
+                    .Include(o => o.Giver)
+                    .ThenInclude(u => u.Address);
+            }
+        }
+
         public OffersRepository(AppDbContext db)
         {
             _db = db;
@@ -21,20 +31,6 @@ namespace backend.Repositories
         {
             _db.Offers.Add(offer);
             _db.SaveChanges();
-        }
-
-        public IQueryable<Offer> FindAll()
-        {
-            return _db.Offers
-                .Include(o => o.Address)
-                .Include(o => o.Food)
-                .Include(o => o.Giver)
-                .ThenInclude(u => u.Address);
-        }
-
-        public IQueryable<Offer> FindByCondition(Expression<Func<Offer, bool>> expression)
-        {
-            return FindAll().Where(expression);
         }
 
         public void Update (Offer offer, UpdateOfferDto updateOfferDto, FoodDto foodDto)

--- a/src/backend/Repositories/ReservationsRepository.cs
+++ b/src/backend/Repositories/ReservationsRepository.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Linq;
-using System.Linq.Expressions;
 using backend.Data;
 using backend.Models;
 using Microsoft.EntityFrameworkCore;
@@ -10,6 +8,11 @@ namespace backend.Repositories
     public class ReservationsRepository : IRepositoryBase<Reservation>
     {
         private readonly AppDbContext _db;
+        
+        public IQueryable<Reservation> Items =>
+            _db.Reservations
+            .Include(r => r.User)
+            .Include(r => r.Offer);
 
         public ReservationsRepository(AppDbContext db)
         {
@@ -20,18 +23,6 @@ namespace backend.Repositories
         {
             _db.Reservations.Add(reservation);
             _db.SaveChanges();
-        }
-
-        public IQueryable<Reservation> FindAll()
-        {
-            return _db.Reservations
-                .Include(r => r.User)
-                .Include(r => r.Offer);
-        }
-
-        public IQueryable<Reservation> FindByCondition(Expression<Func<Reservation, bool>> expression)
-        {
-            return FindAll().Where(expression);
         }
 
         public void Delete(Reservation reservation)

--- a/src/backend/Repositories/UsersRepository.cs
+++ b/src/backend/Repositories/UsersRepository.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq;
 using backend.Data;
 using backend.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace backend.Repositories
 {
-    public class UsersRepository: IRepositoryBase<User>
+    public class UsersRepository : IRepositoryBase<User>
     {
         private readonly AppDbContext _db;
+
+        public IQueryable<User> Items => _db.Users.Include(u => u.Address);
 
         public UsersRepository(AppDbContext db)
         {
@@ -20,16 +20,6 @@ namespace backend.Repositories
         {
             _db.Users.Add(user);
             _db.SaveChanges();
-        }
-
-        public IQueryable<User> FindAll()
-        {
-            return _db.Users.Include(u => u.Address);
-        }
-
-        public IQueryable<User> FindByCondition(Expression<Func<User, bool>> expression)
-        {
-            return FindAll().Where(expression);
         }
     }
 }

--- a/src/backend/Services/CustomCookieAuthEvents.cs
+++ b/src/backend/Services/CustomCookieAuthEvents.cs
@@ -34,7 +34,7 @@ namespace backend.Services
         {
             var userId = int.Parse(context.Principal.Identity.Name);
 
-            var user = _usersRepository.FindByCondition(u => u.Id == userId).FirstOrDefault();
+            var user = _usersRepository.Items.FirstOrDefault(u => u.Id == userId);
 
             if (user == null)
             {

--- a/src/backend/Services/OffersService.cs
+++ b/src/backend/Services/OffersService.cs
@@ -33,7 +33,7 @@ namespace backend.Services
 
         public Offer FindById(int id)
         {
-            var offer = _offersRepository.FindByCondition(o => o.Id == id).FirstOrDefault();
+            var offer = _offersRepository.Items.FirstOrDefault(o => o.Id == id);
 
             if (offer == null)
             {
@@ -56,8 +56,8 @@ namespace backend.Services
             };
             
             var offers = includeExpired
-                ? _offersRepository.FindAll()
-                : _offersRepository.FindByCondition(o => o.ExpiresAt > DateTime.Now);
+                ? _offersRepository.Items
+                : _offersRepository.Items.Where(o => o.ExpiresAt > DateTime.Now);
 
             var orderedOffers = offers.OrderByDescending(o => o.ExpiresAt);
 

--- a/src/backend/Services/ReservationsService.cs
+++ b/src/backend/Services/ReservationsService.cs
@@ -33,8 +33,6 @@ namespace backend.Services
                 }
                 catch (DbUpdateConcurrencyException ex)
                 {
-                    Console.WriteLine("conflict");
-                    
                     foreach (var entry in ex.Entries)
                     {
                         if (entry.Entity is Offer)
@@ -70,9 +68,7 @@ namespace backend.Services
 
         public Reservation FindById(int id)
         {
-            var reservation = _reservationsRepository
-                .FindByCondition(r => r.Id == id)
-                .FirstOrDefault();
+            var reservation = _reservationsRepository.Items.FirstOrDefault(r => r.Id == id);
 
             if (reservation == null)
             {

--- a/src/backend/Services/UsersService.cs
+++ b/src/backend/Services/UsersService.cs
@@ -22,7 +22,7 @@ namespace backend.Services
 
         public User GetByEmail(string email)
         {
-            return _usersRepository.FindByCondition(u => u.Email == email).FirstOrDefault();
+            return _usersRepository.Items.FirstOrDefault(u => u.Email == email);
         }
 
         public User IsValidLogin(string email, string password)

--- a/src/frontend/src/routes/offers/Offers/components/CreateOfferDrawer.tsx
+++ b/src/frontend/src/routes/offers/Offers/components/CreateOfferDrawer.tsx
@@ -4,7 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { DatePickerInput, FieldWithController, FilePicker, Input } from 'components';
 import api from 'contexts/apiContext';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation } from 'react-query';
 import { endOfDay } from 'date-fns';
 
 interface ICreateOfferDrawer {
@@ -16,6 +16,7 @@ interface FormValues {
   foodName: string,
   foodPhoto: File[] | null,
   foodUnit: string,
+  foodMinQuantity: string,
   offerQuantity: number | string,
   offerDescription: string,
   offerExpirationDate: Date | null,
@@ -25,6 +26,7 @@ const validationSchema = yup.object({
   foodName: yup.string().required("This field is required"),
   foodPhoto: yup.array().length(1, "Please upload a photo"),
   foodUnit: yup.string().required("Please choose a unit"),
+  foodMinQuantity: yup.string().required("Please choose the minimum quantity"),
   offerQuantity: yup.number().typeError("Please provide the quantity"),
   offerExpirationDate: yup.date().typeError("Please set an expiration date"),
   offerDescription: yup.string(),
@@ -44,15 +46,14 @@ function CreateOfferContent({ onClose }: { onClose: () => void }) {
       foodPhoto: [],
       offerQuantity: '',
       foodUnit: 'pcs',
+      foodMinQuantity: '1',
       offerExpirationDate: null,
       offerDescription: '',
     }
   });
 
-  const queryClient = useQueryClient();
   const { mutate, isLoading } = useMutation(createOffer, {
     onSuccess: () => {
-      queryClient.invalidateQueries('offers');
       onClose();
     },
     onError: (error: Error) => {
@@ -66,6 +67,7 @@ function CreateOfferContent({ onClose }: { onClose: () => void }) {
     formData.append('foodName', data.foodName);
     formData.append('foodPhoto', data.foodPhoto![0]);
     formData.append('foodUnit', data.foodUnit);
+    formData.append('foodMinQuantity', data.foodMinQuantity)
     formData.append('quantity', data.offerQuantity.toString());
     formData.append('expiresAt', endOfDay(data.offerExpirationDate!).toJSON());
     formData.append('description', data.offerDescription);
@@ -100,15 +102,49 @@ function CreateOfferContent({ onClose }: { onClose: () => void }) {
                     borderColor: 'brand.500',
                   }}
                 >
-                  <option value="g">g (grams)</option>
+                  <option value="pcs">pcs (pieces)</option>
                   <option value="kg">kg (kilograms)</option>
+                  <option value="g">g (grams)</option>
                   <option value="l">l (litres)</option>
                   <option value="ml">ml (mililitres)</option>
-                  <option value="pcs">pcs (pieces)</option>
                 </Select>
               )}
             </FieldWithController>
-            <FieldWithController control={control} name="offerExpirationDate" label="Expiration date">
+            <FieldWithController
+              control={control}
+              name="foodMinQuantity"
+              label="Mininum reservable amount">
+              {(props) => (
+                <Select
+                  {...props}
+                  borderWidth="2px"
+                  borderColor="gray.300"
+                  _hover={{
+                    borderColor: 'gray.400',
+                  }}
+                  _focus={{
+                    borderColor: 'brand.500',
+                  }}
+                >
+                  <option value="1">1</option>
+                  <option value="0.1">0.1</option>
+                  <option value="0.25">0.25</option>
+                  <option value="0.5">0.5</option>
+                  <option value="2">2</option>
+                  <option value="5">5</option>
+                  <option value="10">10</option>
+                  <option value="100">100</option>
+                  <option value="250">250</option>
+                  <option value="500">500</option>
+                </Select>
+              )}
+            </FieldWithController>
+            <FieldWithController
+              control={control}
+              name="offerExpirationDate"
+              label="Expiration date"
+              helperText="After this date, the offer will be hidden and no longer accept new reservations"
+            >
               {(props) => <DatePickerInput {...props} disablePast weekStartsOnMonday />}
             </FieldWithController>
             <FieldWithController control={control} name="offerDescription" label="Description">


### PR DESCRIPTION
I got fed up with how repository `Find*` methods are just there to make querying the `DbSet`s harder and decided to replace these ugly methods with a single `Items` property in every repository that exposes an `IQueryable` with relevant navigation properties included. That makes code in services way cleaner and allows to leverage full `DbSet` functionality in a clean way. The repositories still encapsulate the DbSet that they are responsible for and include navigation properties but now the services can directly call LINQ methods on the repository, such as `FirstOrDefault(<predicate>)`, which makes for much cleaner code. Just take a look 👀 